### PR TITLE
Improve cluster failover with heartbeat manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ Example `broker.yaml`:
 ```yaml
 grpcPort:       9090
 clusterSize:    3
+replicationFactor: 2
 nodeId:         0
 totalPartitions: 16
 ringSize:       1048576
@@ -179,6 +180,7 @@ This design isolates high-throughput message flows from low-volume admin logic.
 |------------------|---------|------------------------------------------|
 | `grpcPort`       | int     | Port for gRPC admin interface            |
 | `clusterSize`    | int     | Total number of nodes in the cluster     |
+| `replicationFactor`| int   | Number of replicas per partition        |
 | `nodeId`         | int     | This node's ID (0-based)                 |
 | `totalPartitions`| int     | Number of partitions globally            |
 | `ringSize`       | int     | In-memory ring size (slots per partition)|

--- a/src/main/java/io/ringbroker/Application.java
+++ b/src/main/java/io/ringbroker/Application.java
@@ -108,6 +108,7 @@ public class Application {
                 new AdaptiveSpin(),
                 cfg.getSegmentBytes(),
                 cfg.getBatchSize(),
+                cfg.getReplicationFactor(),
                 cfg.isIdempotentMode(),
                 store
         );

--- a/src/main/java/io/ringbroker/cluster/client/RemoteBrokerClient.java
+++ b/src/main/java/io/ringbroker/cluster/client/RemoteBrokerClient.java
@@ -19,4 +19,13 @@ public interface RemoteBrokerClient {
      * @param payload message payload bytes
      */
     void sendMessage(String topic, byte[] key, byte[] payload);
+
+    /**
+     * Sends a heartbeat to the remote broker.
+     *
+     * @param fromNode the ID of the sending node
+     */
+    default void sendHeartbeat(int fromNode) {
+        // optional operation
+    }
 }

--- a/src/main/java/io/ringbroker/cluster/client/impl/NettyClusterClient.java
+++ b/src/main/java/io/ringbroker/cluster/client/impl/NettyClusterClient.java
@@ -69,6 +69,12 @@ public final class NettyClusterClient implements RemoteBrokerClient {
         channel.writeAndFlush(BrokerApi.Envelope.newBuilder().setPublish(message).build());
     }
 
+    @Override
+    public void sendHeartbeat(final int fromNode) {
+        // Heartbeats reuse the Envelope frame with no payload
+        channel.writeAndFlush(BrokerApi.Envelope.newBuilder().build());
+    }
+
     public void close() {
         channel.close();
         group.shutdownGracefully();

--- a/src/main/java/io/ringbroker/cluster/manager/ClusterManager.java
+++ b/src/main/java/io/ringbroker/cluster/manager/ClusterManager.java
@@ -1,0 +1,136 @@
+package io.ringbroker.cluster.manager;
+
+import io.ringbroker.cluster.client.RemoteBrokerClient;
+
+import java.util.*;
+
+/**
+ * Simple in-memory cluster manager that keeps track of active broker nodes and
+ * determines the current leader for each partition based on a deterministic
+ * ordering of node IDs. This implementation does not perform any network
+ * heartbeating; nodes must be marked up/down by the application.
+ */
+public final class ClusterManager {
+    private final Map<Integer, RemoteBrokerClient> clients;
+    private final List<Integer> allNodes;
+    private final Set<Integer> activeNodes = new HashSet<>();
+    private final Map<Integer, Long> lastHeartbeat = new HashMap<>();
+    private final int replicationFactor;
+    private final long heartbeatTimeoutMillis;
+
+    public ClusterManager(Map<Integer, RemoteBrokerClient> clients,
+                          int myNodeId,
+                          int replicationFactor) {
+        this(clients, myNodeId, replicationFactor, 10_000);
+    }
+
+    public ClusterManager(Map<Integer, RemoteBrokerClient> clients,
+                          int myNodeId,
+                          int replicationFactor,
+                          long heartbeatTimeoutMillis) {
+        this.clients = clients;
+        this.allNodes = new ArrayList<>(clients.keySet());
+        this.allNodes.add(myNodeId); // include self
+        Collections.sort(this.allNodes);
+        this.activeNodes.addAll(this.allNodes);
+        this.replicationFactor = replicationFactor;
+        this.heartbeatTimeoutMillis = heartbeatTimeoutMillis;
+        long now = System.currentTimeMillis();
+        for (Integer n : this.allNodes) {
+            lastHeartbeat.put(n, now);
+        }
+    }
+
+    /** Mark a node as failed/inactive. */
+    public synchronized void nodeDown(int nodeId) {
+        activeNodes.remove(nodeId);
+    }
+
+    /** Mark a node as alive/active. */
+    public synchronized void nodeUp(int nodeId) {
+        if (allNodes.contains(nodeId)) {
+            activeNodes.add(nodeId);
+            lastHeartbeat.put(nodeId, System.currentTimeMillis());
+        }
+    }
+
+    /** Record a heartbeat from the given node. */
+    public synchronized void handleHeartbeat(int nodeId) {
+        handleHeartbeat(nodeId, System.currentTimeMillis());
+    }
+
+    synchronized void handleHeartbeat(int nodeId, long now) {
+        if (allNodes.contains(nodeId)) {
+            activeNodes.add(nodeId);
+            lastHeartbeat.put(nodeId, now);
+        }
+    }
+
+    /** Remove nodes whose heartbeat timed out. */
+    public synchronized void checkHeartbeats() {
+        checkHeartbeats(System.currentTimeMillis());
+    }
+
+    synchronized void checkHeartbeats(long now) {
+        Iterator<Integer> it = activeNodes.iterator();
+        while (it.hasNext()) {
+            int n = it.next();
+            long last = lastHeartbeat.getOrDefault(n, 0L);
+            if (now - last > heartbeatTimeoutMillis) {
+                it.remove();
+            }
+        }
+    }
+
+    /** Returns true if this node is the leader for the given partition. */
+    public synchronized boolean isLeader(int partitionId, int nodeId) {
+        return getLeader(partitionId) == nodeId;
+    }
+
+    /** Determine the current leader for the given partition. */
+    public synchronized int getLeader(int partitionId) {
+        checkHeartbeats();
+        return replicasFor(partitionId).getFirst();
+    }
+
+    /** Return the list of replica node ids for a partition (leader first). */
+    public synchronized List<Integer> replicasFor(int partitionId) {
+        checkHeartbeats();
+        List<Integer> replicas = new ArrayList<>();
+        int rf = Math.min(replicationFactor, allNodes.size());
+        int base = Math.floorMod(partitionId, allNodes.size());
+
+        int i = 0;
+        while (replicas.size() < rf && i < allNodes.size()) {
+            int candidate = allNodes.get((base + i) % allNodes.size());
+            if (activeNodes.contains(candidate)) {
+                replicas.add(candidate);
+            }
+            i++;
+        }
+
+        if (replicas.isEmpty()) {
+            throw new IllegalStateException("No active nodes");
+        }
+
+        return replicas;
+    }
+
+    /** Follower replicas (excludes the leader). */
+    public synchronized List<Integer> followersFor(int partitionId) {
+        List<Integer> replicas = replicasFor(partitionId);
+        if (!replicas.isEmpty()) replicas.removeFirst();
+        return replicas;
+    }
+
+    /** Lookup the client for the given node id. */
+    public synchronized RemoteBrokerClient clientFor(int nodeId) {
+        return clients.get(nodeId);
+    }
+
+    private List<Integer> activeOrdered() {
+        List<Integer> ordered = new ArrayList<>(activeNodes);
+        ordered.sort(Integer::compareTo);
+        return ordered;
+    }
+}

--- a/src/main/java/io/ringbroker/config/impl/BrokerConfig.java
+++ b/src/main/java/io/ringbroker/config/impl/BrokerConfig.java
@@ -51,6 +51,7 @@ public final class BrokerConfig {
     private int ingressThreads;
     private int batchSize;
     private boolean idempotentMode;
+    private int replicationFactor;
 
     /**
      * Loads broker configuration from a YAML file at the specified path.
@@ -82,6 +83,8 @@ public final class BrokerConfig {
             cfg.segmentBytes = (Integer) map.get("segmentBytes");
             cfg.batchSize = (Integer) map.get("batchSize");
             cfg.idempotentMode = (Boolean) map.get("idempotentMode");
+            Object rf = map.get("replicationFactor");
+            cfg.replicationFactor = rf == null ? 1 : (Integer) rf;
 
             return cfg;
         }

--- a/src/test/java/io/ringbroker/cluster/manager/ClusterManagerTest.java
+++ b/src/test/java/io/ringbroker/cluster/manager/ClusterManagerTest.java
@@ -1,0 +1,66 @@
+package io.ringbroker.cluster.manager;
+
+import io.ringbroker.cluster.client.RemoteBrokerClient;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class ClusterManagerTest {
+    @Test
+    public void testLeaderChangesWhenNodeDown() {
+        Map<Integer, RemoteBrokerClient> clients = new HashMap<>();
+        clients.put(1, null);
+        clients.put(2, null);
+        ClusterManager mgr = new ClusterManager(clients, 0, 2);
+
+        // start with only node 0 active
+        mgr.nodeDown(1);
+        mgr.nodeDown(2);
+
+        assertTrue(mgr.isLeader(1, 0));
+
+        // add other nodes
+        mgr.nodeUp(1);
+        mgr.nodeUp(2);
+
+        // leader for partition 1 should now be node 1
+        assertEquals(1, mgr.getLeader(1));
+
+        // simulate node 0 down -> leader becomes 1
+        mgr.nodeDown(0);
+        assertEquals(1, mgr.getLeader(1));
+    }
+
+    @Test
+    public void testReplicasForPartition() {
+        Map<Integer, RemoteBrokerClient> clients = new HashMap<>();
+        clients.put(1, null);
+        clients.put(2, null);
+        ClusterManager mgr = new ClusterManager(clients, 0, 2);
+
+        mgr.nodeUp(1);
+        mgr.nodeUp(2);
+
+        var replicas = mgr.replicasFor(0);
+        assertEquals(2, replicas.size());
+        assertEquals(0, replicas.getFirst());
+        assertEquals(1, replicas.get(1));
+    }
+
+    @Test
+    public void testHeartbeatTimeoutRemovesNode() {
+        Map<Integer, RemoteBrokerClient> clients = new HashMap<>();
+        clients.put(1, null);
+        ClusterManager mgr = new ClusterManager(clients, 0, 2, 50);
+
+        mgr.nodeUp(1);
+        mgr.handleHeartbeat(1, 0);
+
+        mgr.checkHeartbeats(100);
+
+        assertFalse(mgr.replicasFor(0).contains(1), "node 1 should be inactive");
+    }
+}

--- a/src/test/java/io/ringbroker/test/SanityCheckMain.java
+++ b/src/test/java/io/ringbroker/test/SanityCheckMain.java
@@ -66,7 +66,8 @@ class SanityCheckMain {
                 new AdaptiveSpin(),
                 SEGMENT_BYTES,
                 BATCH_SIZE,
-                /* flushOnWrite */ false,
+                1,
+                false,
                 new InMemoryOffsetStore()
         );
 


### PR DESCRIPTION
## Summary
- add heartbeat support to `ClusterManager`
- extend `RemoteBrokerClient` with optional heartbeat method
- implement heartbeat sending in `NettyClusterClient`
- adjust `ClusterManagerTest` for new logic
- fix `SanityCheckMain` call to `ClusteredIngress.create`

## Testing
- `./gradlew test --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_68403e56c1e883268790bf50325b96e7