### PR TITLE
Add basic cluster manager with leader election

### DIFF
--- a/src/main/java/io/ringbroker/broker/ingress/ClusteredIngress.java
+++ b/src/main/java/io/ringbroker/broker/ingress/ClusteredIngress.java
@@ -3,6 +3,7 @@ package io.ringbroker.broker.ingress;
 import io.ringbroker.broker.delivery.Delivery;
 import io.ringbroker.cluster.client.RemoteBrokerClient;
 import io.ringbroker.cluster.partitioner.Partitioner;
+import io.ringbroker.cluster.manager.ClusterManager;
 import io.ringbroker.core.ring.RingBuffer;
 import io.ringbroker.core.wait.WaitStrategy;
 import io.ringbroker.offset.OffsetStore;
@@ -38,9 +39,10 @@ public final class ClusteredIngress {
     private final Partitioner partitioner;
     private final int totalPartitions;
     private final int myNodeId;
-    private final int clusterSize;
     private final Map<Integer, Ingress> ingressMap;                     // one Ingress per local partition
+    private final int clusterSize;
     private final Map<Integer, RemoteBrokerClient> clusterNodes;        // stubs to other brokers
+    private final ClusterManager clusterManager;
     private final boolean idempotentMode;
     private final Map<Integer, Set<String>> seenMessageIds;             // only used if idempotentMode
     private final Map<Integer, Delivery> deliveryMap;                   // per-partition delivery
@@ -90,13 +92,16 @@ public final class ClusteredIngress {
             }
         }
 
+        final ClusterManager mgr = new ClusterManager(clusterNodes, myNodeId);
+
         return new ClusteredIngress(
                 partitioner,
                 totalPartitions,
                 myNodeId,
-                clusterSize,
                 ingressMap,
+                clusterSize,
                 clusterNodes,
+                mgr,
                 idempotentMode,
                 seenMessageIds,
                 deliveryMap,
@@ -127,7 +132,7 @@ public final class ClusteredIngress {
      */
     public void publish(final String topic, final byte[] key, final int retries, final byte[] payload) {
         final int partitionId = partitioner.selectPartition(key, totalPartitions);
-        final int owner = Math.floorMod(partitionId, clusterSize);
+        final int owner = clusterManager.getLeader(partitionId);
 
         if (owner == myNodeId) {
             if (idempotentMode) {
@@ -149,7 +154,7 @@ public final class ClusteredIngress {
 
             ingress.publish(topic, retries, payload);
         } else {
-            final RemoteBrokerClient client = clusterNodes.get(owner);
+            final RemoteBrokerClient client = clusterManager.clientFor(owner);
 
             if (client == null) {
                 log.error("No RemoteBrokerClient for node {} (partition {})", owner, partitionId);

--- a/src/main/java/io/ringbroker/cluster/manager/ClusterManager.java
+++ b/src/main/java/io/ringbroker/cluster/manager/ClusterManager.java
@@ -1,0 +1,61 @@
+package io.ringbroker.cluster.manager;
+
+import io.ringbroker.cluster.client.RemoteBrokerClient;
+
+import java.util.*;
+
+/**
+ * Simple in-memory cluster manager that keeps track of active broker nodes and
+ * determines the current leader for each partition based on a deterministic
+ * ordering of node IDs. This implementation does not perform any network
+ * heartbeating; nodes must be marked up/down by the application.
+ */
+public final class ClusterManager {
+    private final Map<Integer, RemoteBrokerClient> clients;
+    private final List<Integer> allNodes;
+    private final Set<Integer> activeNodes = new HashSet<>();
+
+    public ClusterManager(Map<Integer, RemoteBrokerClient> clients, int myNodeId) {
+        this.clients = clients;
+        this.allNodes = new ArrayList<>(clients.keySet());
+        this.allNodes.add(myNodeId); // include self
+        Collections.sort(this.allNodes);
+        this.activeNodes.addAll(this.allNodes);
+    }
+
+    /** Mark a node as failed/inactive. */
+    public synchronized void nodeDown(int nodeId) {
+        activeNodes.remove(nodeId);
+    }
+
+    /** Mark a node as alive/active. */
+    public synchronized void nodeUp(int nodeId) {
+        if (allNodes.contains(nodeId)) {
+            activeNodes.add(nodeId);
+        }
+    }
+
+    /** Returns true if this node is the leader for the given partition. */
+    public synchronized boolean isLeader(int partitionId, int nodeId) {
+        return getLeader(partitionId) == nodeId;
+    }
+
+    /** Determine the current leader for the given partition. */
+    public synchronized int getLeader(int partitionId) {
+        List<Integer> ordered = activeOrdered();
+        if (ordered.isEmpty()) throw new IllegalStateException("No active nodes");
+        int idx = Math.floorMod(partitionId, ordered.size());
+        return ordered.get(idx);
+    }
+
+    /** Lookup the client for the given node id. */
+    public synchronized RemoteBrokerClient clientFor(int nodeId) {
+        return clients.get(nodeId);
+    }
+
+    private List<Integer> activeOrdered() {
+        List<Integer> ordered = new ArrayList<>(activeNodes);
+        ordered.sort(Integer::compareTo);
+        return ordered;
+    }
+}

--- a/src/test/java/io/ringbroker/cluster/manager/ClusterManagerTest.java
+++ b/src/test/java/io/ringbroker/cluster/manager/ClusterManagerTest.java
@@ -1,0 +1,33 @@
+package io.ringbroker.cluster.manager;
+
+import io.ringbroker.cluster.client.RemoteBrokerClient;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class ClusterManagerTest {
+    @Test
+    public void testLeaderChangesWhenNodeDown() {
+        Map<Integer, RemoteBrokerClient> clients = new HashMap<>();
+        ClusterManager mgr = new ClusterManager(clients, 0);
+
+        // cluster of single node (0) only
+        assertTrue(mgr.isLeader(1, 0));
+
+        // add other nodes
+        clients.put(1, null);
+        clients.put(2, null);
+        mgr.nodeUp(1);
+        mgr.nodeUp(2);
+
+        // leader for partition 1 should be node 0
+        assertEquals(0, mgr.getLeader(1));
+
+        // simulate node 0 down -> leader becomes 1
+        mgr.nodeDown(0);
+        assertEquals(1, mgr.getLeader(1));
+    }
+}


### PR DESCRIPTION
## Summary
- introduce a simple in-memory `ClusterManager` that keeps track of active nodes and elects a leader for each partition
- integrate `ClusterManager` into `ClusteredIngress` so publishing targets the elected leader
- add unit test for `ClusterManager` logic

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68403e56c1e883268790bf50325b96e7